### PR TITLE
Add MacOS support for setting Vim9cordSocketLocation

### DIFF
--- a/autoload/vim9cord.vim
+++ b/autoload/vim9cord.vim
@@ -15,7 +15,9 @@ export def Init()
     #
     # This if statement is redundant, but left for future compatibility
     # reasons
-    if has("linux")
+    if has("mac")
+        g:Vim9cordSocketLocation = "unix:" .. $TMPDIR .. "discord-ipc-0"
+    elseif has("linux")
         g:Vim9cordSocketLocation = "unix:" .. $XDG_RUNTIME_DIR .. "/discord-ipc-0"
     endif
 


### PR DESCRIPTION
Updated `autoload/vim9cord.vim` with the location of the Vim9cordSocketLocation on MacOS. Tested on my Mac (Sequoia 15.0), doesn't work without updated code.